### PR TITLE
Add some IE related hooks

### DIFF
--- a/cuckoomon.c
+++ b/cuckoomon.c
@@ -396,11 +396,12 @@ static hook_t g_hooks[] = {
 	HOOK(kernel32, GlobalMemoryStatusEx),
 	HOOK(user32, SystemParametersInfoA),
 	HOOK(user32, SystemParametersInfoW),
+	HOOK(pstorec, PStoreCreateInstance),
 
 	//
     // Network Hooks
     //
-		
+
 	HOOK(netapi32, NetUserGetInfo),
 	HOOK(netapi32, NetGetJoinInformation),
 	HOOK(netapi32, NetUserGetLocalGroups),
@@ -431,6 +432,8 @@ static hook_t g_hooks[] = {
 	HOOK(wininet, InternetCrackUrlA),
 	HOOK(wininet, InternetCrackUrlW),
 	HOOK(wininet, InternetSetOptionA),
+	HOOK(wininet, InternetConfirmZoneCrossingA),
+	HOOK(wininet, InternetConfirmZoneCrossingW),
 
 	HOOK(winhttp, WinHttpOpen),
 	HOOK(winhttp, WinHttpGetIEProxyConfigForCurrentUser),
@@ -451,6 +454,8 @@ static hook_t g_hooks[] = {
 
 	HOOK(mpr, WNetUseConnectionW),
 	HOOK(cryptnet, CryptRetrieveObjectByUrlW),
+	HOOK(ncrypt, SslEncryptPacket),
+	HOOK(ncrypt, SslDecryptPacket),
 	HOOK(iphlpapi, GetAdaptersAddresses),
 	HOOK(iphlpapi, GetAdaptersInfo),
 	HOOK(urlmon, CoInternetSetFeatureEnabled),

--- a/hook_misc.c
+++ b/hook_misc.c
@@ -991,3 +991,14 @@ HOOKDEF(BOOL, WINAPI, SystemParametersInfoW,
 
 	return ret;
 }
+
+HOOKDEF(HRESULT, WINAPI, PStoreCreateInstance,
+	_Out_ PVOID **ppProvider,
+	_In_  VOID *pProviderID,
+	_In_  VOID *pReserved,
+	_In_  DWORD dwFlags
+) {
+	HRESULT ret = Old_PStoreCreateInstance(ppProvider, pProviderID, pReserved, dwFlags);
+	LOQ_hresult("misc", "");
+	return ret;
+}

--- a/hooks.h
+++ b/hooks.h
@@ -1550,9 +1550,54 @@ extern HOOKDEF(BOOL, WINAPI, SystemParametersInfoW,
 	_In_    UINT  fWinIni
 );
 
+extern HOOKDEF(HRESULT, WINAPI, PStoreCreateInstance,
+	_Out_ PVOID **ppProvider,
+	_In_  VOID  *pProviderID,
+	_In_  VOID  *pReserved,
+	_In_  DWORD dwFlags
+);
+
 //
 // Network Hooks
 //
+extern HOOKDEF(DWORD, WINAPI, InternetConfirmZoneCrossingA,
+	_In_ HWND hWnd,
+	_In_ LPTSTR szUrlPrev,
+	_In_ LPTSTR szUrlNew,
+	_In_ BOOL bPost
+);
+
+extern HOOKDEF(DWORD, WINAPI, InternetConfirmZoneCrossingW,
+	_In_ HWND hWnd,
+	_In_ LPTSTR szUrlPrev,
+	_In_ LPTSTR szUrlNew,
+	_In_ BOOL bPost
+);
+
+extern HOOKDEF(SECURITY_STATUS, WINAPI, SslEncryptPacket,
+	_In_    NCRYPT_PROV_HANDLE hSslProvider,
+	_Inout_ NCRYPT_KEY_HANDLE hKey,
+	_In_    PBYTE pbInput,
+	_In_    DWORD cbInput,
+	_Out_   PBYTE pbOutput,
+	_In_    DWORD cbOutput,
+	_Out_   DWORD *pcbResult,
+	_In_    ULONGLONG SequenceNumber,
+	_In_    DWORD dcContentType,
+	_In_    DWORD dwFlags
+);
+
+extern HOOKDEF(SECURITY_STATUS, WINAPI, SslDecryptPacket,
+	_In_    NCRYPT_PROV_HANDLE hSslProvider,
+	_Inout_ NCRYPT_KEY_HANDLE hKey,
+	_In_    PBYTE pbInput,
+	_In_    DWORD cbInput,
+	_Out_   PBYTE pbOutput,
+	_In_    DWORD cbOutput,
+	_Out_   DWORD *pcbResult,
+	_In_    ULONGLONG SequenceNumber,
+	_In_    DWORD dwFlags
+);
 
 extern HOOKDEF(BOOL, WINAPI, WinHttpSendRequest,
 	_In_      HINTERNET hRequest,


### PR DESCRIPTION
These hooks add increased context to redirects, API visibility to encrypted data (SSL) and also fixes an issue where we'd sometimes inject into lsass.exe due to IE starting the ProtectedStorage service. Currently only tested with IE8.
