### PR TITLE
Add a hook for URLDownloadToCacheFileW

### DIFF
--- a/cuckoomon.c
+++ b/cuckoomon.c
@@ -415,6 +415,7 @@ static hook_t g_hooks[] = {
 	HOOK(netapi32, NetGetJoinInformation),
 	HOOK(netapi32, NetUserGetLocalGroups),
 	HOOK(urlmon, URLDownloadToFileW),
+  HOOK(urlmon, URLDownloadToCacheFileW),
 	HOOK(urlmon, ObtainUserAgentString),
 	HOOK(wininet, InternetGetConnectedState),
     HOOK(wininet, InternetOpenA),

--- a/hook_network.c
+++ b/hook_network.c
@@ -255,13 +255,28 @@ HOOKDEF(HRESULT, WINAPI, URLDownloadToFileW,
     DWORD dwReserved,
     LPVOID lpfnCB
 ) {
-    HRESULT ret = Old_URLDownloadToFileW(pCaller, szURL, szFileName,
-        dwReserved, lpfnCB);
-	LOQ_hresult("network", "uFs", "URL", szURL, "FileName", szFileName, "StackPivoted", is_stack_pivoted() ? "yes" : "no");
-    if(ret == S_OK) {
-        pipe("FILE_NEW:%S", -1, szFileName);
-    }
+    HRESULT ret = Old_URLDownloadToFileW(pCaller, szURL, szFileName, dwReserved, lpfnCB);
+    LOQ_hresult("network", "uFs", "URL", szURL, "FileName", szFileName, "StackPivoted", is_stack_pivoted() ? "yes" : "no");
+    if(ret == S_OK)
+      pipe("FILE_NEW:%Z", szFileName);
+
     return ret;
+}
+
+HOOKDEF(HRESULT, WINAPI, URLDownloadToCacheFileW,
+  _In_ LPUNKNOWN lpUnkcalled,
+  _In_ LPCWSTR szURL,
+  _Out_ LPWSTR szFilename,
+  _In_ DWORD cchFilename,
+  _Reserved_ DWORD dwReserved,
+  _In_opt_ VOID *pBSC
+) {
+  HRESULT ret = Old_URLDownloadToCacheFileW(lpUnkcalled, szURL, szFilename, cchFilename, dwReserved, pBSC);
+  LOQ_hresult("network", "uFs", "URL", szURL, "Filename", ret == S_OK ? szFilename : L"", "StackPivoted", is_stack_pivoted() ? "yes" : "no");
+  if (ret == S_OK)
+    pipe("FILE_NEW:%Z", szFilename);
+
+  return ret;
 }
 
 HOOKDEF(BOOL, WINAPI, InternetGetConnectedState,

--- a/hooks.h
+++ b/hooks.h
@@ -1774,6 +1774,15 @@ extern HOOKDEF(HRESULT, WINAPI, URLDownloadToFileW,
     LPVOID lpfnCB
 );
 
+extern HOOKDEF(HRESULT, WINAPI, URLDownloadToCacheFileW,
+  _In_ LPUNKNOWN lpUnkcalled,
+  _In_ LPCWSTR szURL,
+  _Out_ LPWSTR szFilename,
+  _In_ DWORD cchFilename,
+  _Reserved_ DWORD dwReserved,
+  _In_opt_ VOID *pBSC
+);
+
 extern HOOKDEF(BOOL, WINAPI, InternetGetConnectedState,
 	_Out_ LPDWORD lpdwFlags,
 	_In_ DWORD dwReserved


### PR DESCRIPTION
As requested from https://github.com/spender-sandbox/cuckoo-modified/issues/344
A hook for URLDownloadToCacheFileA is not needed as this API just calls URLDownloadToCacheFileW. Also touched up URLDownloadToFileW to more properly use the unicode format.