### PR TITLE
Log the handle for GetVolumeInformationByHandleW

### DIFF
--- a/hook_file.c
+++ b/hook_file.c
@@ -1194,7 +1194,7 @@ HOOKDEF(BOOL, WINAPI, GetVolumeInformationByHandleW,
 	if (ret && lpVolumeSerialNumber && g_config.serial_number)
 		*lpVolumeSerialNumber = g_config.serial_number;
 
-	LOQ_bool("filesystem", "uH", "VolumeName", lpVolumeNameBuffer, "VolumeSerial", lpVolumeSerialNumber);
+	LOQ_bool("filesystem", "puH", "Handle", hFile, "VolumeName", lpVolumeNameBuffer, "VolumeSerial", lpVolumeSerialNumber);
 
 	return ret;
 }


### PR DESCRIPTION
In some cases VolumeName wasn't populated, but was instead observed in an NtOpenFile call to the drive root prior. The return FileHandle of this can be tracked in signature if we log the handle here as well.