### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/hook_file.c
+++ b/hook_file.c
@@ -404,7 +404,7 @@ HOOKDEF(NTSTATUS, WINAPI, NtReadFile,
 		if (read_count < 50)
 			LOQ_ntstatus("filesystem", "pFbl", "FileHandle", FileHandle,
 				"HandleName", fname, "Buffer", InitialBufferLength, InitialBuffer, "Length", AccumulatedLength);
-		else if (read_count == 50)
+		else
 			LOQ_ntstatus("filesystem", "pFbls", "FileHandle", FileHandle,
 				"HandleName", fname, "Buffer", InitialBufferLength, InitialBuffer, "Length", AccumulatedLength, "Status", "Maximum logged reads reached for this file");
 
@@ -445,11 +445,9 @@ HOOKDEF(NTSTATUS, WINAPI, NtWriteFile,
 			LOQ_ntstatus("filesystem", "pFbl", "FileHandle", FileHandle,
 				"HandleName", fname, "Buffer", length, Buffer, "Length", length);
 		}
-		else if (write_count == 50) {
+		else 
 			LOQ_ntstatus("filesystem", "pFbls", "FileHandle", FileHandle,
 				"HandleName", fname, "Buffer", length, Buffer, "Length", length, "Status", "Maximum logged writes reached for this file");
-
-		}
 
 		free(fname);
 	}

--- a/hook_sleep.c
+++ b/hook_sleep.c
@@ -119,7 +119,7 @@ HOOKDEF(NTSTATUS, WINAPI, NtWaitForSingleObject,
 			LOQ_ntstatus("system", "s", "Status", "Small log limit reached");
 			num_wait_small++;
 		}
-		else if (num_wait_small > 20) {
+		else {
 			// likely using a bunch of tiny sleeps to delay execution, so let's suddenly mimic high load and give our
 			// fake passage of time the impression of longer delays to return from sleep
 			time_skipped.QuadPart += (randint(500, 1000) * 10000);
@@ -213,7 +213,7 @@ HOOKDEF(NTSTATUS, WINAPI, NtDelayExecution,
 			LOQ_ntstatus("system", "s", "Status", "Small log limit reached");
 			num_small++;
 		}
-		else if (num_small > 20) {
+		else {
 			// likely using a bunch of tiny sleeps to delay execution, so let's suddenly mimic high load and give our
 			// fake passage of time the impression of longer delays to return from sleep
 			time_skipped.QuadPart += (randint(500, 1000) * 10000);
@@ -267,7 +267,7 @@ HOOKDEF(DWORD, WINAPI, MsgWaitForMultipleObjectsEx,
 			LOQ_msgwait("system", "s", "Status", "Small log limit reached");
 			num_msg_small++;
 		}
-		else if (num_msg_small > 20) {
+		else {
 			// likely using a bunch of tiny sleeps to delay execution, so let's suddenly mimic high load and give our
 			// fake passage of time the impression of longer delays to return from sleep
 			time_skipped.QuadPart += (randint(500, 1000) * 10000);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V547](https://www.viva64.com/en/w/v547/) Expression 'read_count == 50' is always true. hook_file.c 407, 448
[V547](https://www.viva64.com/en/w/v547/) Expression 'num_wait_small > 20' is always true. hook_sleep.c 122
[V547](https://www.viva64.com/en/w/v547/) Expression 'num_small > 20' is always true. hook_sleep.c 216
[V547](https://www.viva64.com/en/w/v547/) Expression 'num_msg_small > 20' is always true. hook_sleep.c 270