### PR TITLE
Fixed a parameter validation issue

### DIFF
--- a/hook_process.c
+++ b/hook_process.c
@@ -215,13 +215,41 @@ HOOKDEF(BOOL, WINAPI, CreateProcessWithLogonW,
 
 	ret = Old_CreateProcessWithLogonW(lpUsername, lpDomain, lpPassword, dwLogonFlags, lpApplicationName, lpCommandLine, dwCreationFlags | CREATE_SUSPENDED, lpEnvironment, lpCurrentDirectory, lpStartupInfo, lpProcessInfo);
 
-	LOQ_bool("process", "uuuhuuhiipp", "Username", lpUsername, "Domain", lpDomain, "Password", lpPassword, "LogonFlags", dwLogonFlags, "ApplicationName", lpApplicationName, "CommandLine", origcommandline, "CreationFlags", dwCreationFlags,
-		"ProcessId", lpProcessInfo->dwProcessId, "ThreadId", lpProcessInfo->dwThreadId, "ProcessHandle", lpProcessInfo->hProcess, "ThreadHandle", lpProcessInfo->hThread);
+	if (lpProcessInfo) {
+		LOQ_bool("process", "uuuhuuhiipp",
+			"Username", lpUsername,
+			"Domain", lpDomain,
+			"Password", lpPassword,
+			"LogonFlags", dwLogonFlags,
+			"ApplicationName", lpApplicationName,
+			"CommandLine", origcommandline,
+			"CreationFlags", dwCreationFlags,
+			"ProcessId", lpProcessInfo->dwProcessId,
+			"ThreadId", lpProcessInfo->dwThreadId,
+			"ProcessHandle", lpProcessInfo->hProcess,
+			"ThreadHandle", lpProcessInfo->hThread
+		);
+	}
+	else {
+		LOQ_bool("process", "uuuhuuhiipp",
+			"Username", lpUsername,
+			"Domain", lpDomain,
+			"Password", lpPassword,
+			"LogonFlags", dwLogonFlags,
+			"ApplicationName", lpApplicationName,
+			"CommandLine", origcommandline,
+			"CreationFlags", dwCreationFlags,
+			"ProcessId", NULL,
+			"ThreadId", NULL,
+			"ProcessHandle", NULL,
+			"ThreadHandle", NULL
+		);
+	}
 
 	if (origcommandline)
 		free(origcommandline);
 
-	if (ret) {
+	if (ret && lpProcessInfo) {
 		pipe("PROCESS:%d:%d,%d", is_suspended(lpProcessInfo->dwProcessId, lpProcessInfo->dwThreadId), lpProcessInfo->dwProcessId, lpProcessInfo->dwThreadId);
 		if (!(dwCreationFlags & CREATE_SUSPENDED))
 			ResumeThread(lpProcessInfo->hThread);
@@ -249,13 +277,35 @@ HOOKDEF(BOOL, WINAPI, CreateProcessWithTokenW,
 
 	ret = Old_CreateProcessWithTokenW(hToken, dwLogonFlags, lpApplicationName, lpCommandLine, dwCreationFlags | CREATE_SUSPENDED, lpEnvironment, lpCurrentDirectory, lpStartupInfo, lpProcessInfo);
 
-	LOQ_bool("process", "huuhiipp", "LogonFlags", dwLogonFlags, "ApplicationName", lpApplicationName, "CommandLine", origcommandline, "CreationFlags", dwCreationFlags,
-		"ProcessId", lpProcessInfo->dwProcessId, "ThreadId", lpProcessInfo->dwThreadId, "ProcessHandle", lpProcessInfo->hProcess, "ThreadHandle", lpProcessInfo->hThread);
+	if (lpProcessInfo) {
+		LOQ_bool("process", "huuhiipp",
+			"LogonFlags", dwLogonFlags,
+			"ApplicationName", lpApplicationName,
+			"CommandLine", origcommandline,
+			"CreationFlags", dwCreationFlags,
+			"ProcessId", lpProcessInfo->dwProcessId,
+			"ThreadId", lpProcessInfo->dwThreadId,
+			"ProcessHandle", lpProcessInfo->hProcess,
+			"ThreadHandle", lpProcessInfo->hThread
+		);
+	}
+	else {
+		LOQ_bool("process", "huuhiipp",
+			"LogonFlags", dwLogonFlags,
+			"ApplicationName", lpApplicationName,
+			"CommandLine", origcommandline,
+			"CreationFlags", dwCreationFlags,
+			"ProcessId", NULL,
+			"ThreadId", NULL,
+			"ProcessHandle", NULL,
+			"ThreadHandle", NULL
+		);
+	}
 
 	if (origcommandline)
 		free(origcommandline);
 
-	if (ret) {
+	if (ret && lpProcessInfo) {
 		pipe("PROCESS:%d:%d,%d", is_suspended(lpProcessInfo->dwProcessId, lpProcessInfo->dwThreadId), lpProcessInfo->dwProcessId, lpProcessInfo->dwThreadId);
 		if (!(dwCreationFlags & CREATE_SUSPENDED))
 			ResumeThread(lpProcessInfo->hThread);

--- a/hook_process.c
+++ b/hook_process.c
@@ -209,47 +209,31 @@ HOOKDEF(BOOL, WINAPI, CreateProcessWithLogonW,
 ) {
 	BOOL ret;
 	LPWSTR origcommandline = NULL;
-	
+	ENSURE_STRUCT(lpProcessInfo, PROCESS_INFORMATION);
+
 	if (lpCommandLine)
 		origcommandline = wcsdup(lpCommandLine);
 
 	ret = Old_CreateProcessWithLogonW(lpUsername, lpDomain, lpPassword, dwLogonFlags, lpApplicationName, lpCommandLine, dwCreationFlags | CREATE_SUSPENDED, lpEnvironment, lpCurrentDirectory, lpStartupInfo, lpProcessInfo);
 
-	if (lpProcessInfo) {
-		LOQ_bool("process", "uuuhuuhiipp",
-			"Username", lpUsername,
-			"Domain", lpDomain,
-			"Password", lpPassword,
-			"LogonFlags", dwLogonFlags,
-			"ApplicationName", lpApplicationName,
-			"CommandLine", origcommandline,
-			"CreationFlags", dwCreationFlags,
-			"ProcessId", lpProcessInfo->dwProcessId,
-			"ThreadId", lpProcessInfo->dwThreadId,
-			"ProcessHandle", lpProcessInfo->hProcess,
-			"ThreadHandle", lpProcessInfo->hThread
-		);
-	}
-	else {
-		LOQ_bool("process", "uuuhuuhiipp",
-			"Username", lpUsername,
-			"Domain", lpDomain,
-			"Password", lpPassword,
-			"LogonFlags", dwLogonFlags,
-			"ApplicationName", lpApplicationName,
-			"CommandLine", origcommandline,
-			"CreationFlags", dwCreationFlags,
-			"ProcessId", NULL,
-			"ThreadId", NULL,
-			"ProcessHandle", NULL,
-			"ThreadHandle", NULL
-		);
-	}
+	LOQ_bool("process", "uuuhuuhiipp",
+		"Username", lpUsername,
+		"Domain", lpDomain,
+		"Password", lpPassword,
+		"LogonFlags", dwLogonFlags,
+		"ApplicationName", lpApplicationName,
+		"CommandLine", origcommandline,
+		"CreationFlags", dwCreationFlags,
+		"ProcessId", lpProcessInfo->dwProcessId,
+		"ThreadId", lpProcessInfo->dwThreadId,
+		"ProcessHandle", lpProcessInfo->hProcess,
+		"ThreadHandle", lpProcessInfo->hThread
+	);
 
 	if (origcommandline)
 		free(origcommandline);
 
-	if (ret && lpProcessInfo) {
+	if (ret) {
 		pipe("PROCESS:%d:%d,%d", is_suspended(lpProcessInfo->dwProcessId, lpProcessInfo->dwThreadId), lpProcessInfo->dwProcessId, lpProcessInfo->dwThreadId);
 		if (!(dwCreationFlags & CREATE_SUSPENDED))
 			ResumeThread(lpProcessInfo->hThread);

--- a/hook_process.c
+++ b/hook_process.c
@@ -656,7 +656,7 @@ HOOKDEF(NTSTATUS, WINAPI, NtProtectVirtualMemory,
         NumberOfBytesToProtect, NewAccessProtection, OldAccessProtection);
 
 	/* Don't log an uninteresting case */
-	if (OldAccessProtection && *OldAccessProtection == NewAccessProtection)
+	if (NT_SUCCESS(ret) && OldAccessProtection && *OldAccessProtection == NewAccessProtection)
 		return ret;
 
 	memset(&meminfo, 0, sizeof(meminfo));
@@ -703,7 +703,7 @@ HOOKDEF(BOOL, WINAPI, VirtualProtectEx,
         lpflOldProtect);
 
 	/* Don't log an uninteresting case */
-	if (lpflOldProtect && *lpflOldProtect == flNewProtect)
+	if (ret && lpflOldProtect && *lpflOldProtect == flNewProtect)
 		return ret;
 
 	memset(&meminfo, 0, sizeof(meminfo));

--- a/hook_thread.c
+++ b/hook_thread.c
@@ -165,7 +165,7 @@ HOOKDEF(NTSTATUS, WINAPI, NtCreateThreadEx,
     OUT     PVOID lpBytesBuffer
 ) {
 	DWORD pid = pid_from_process_handle(ProcessHandle);
-	
+
 	NTSTATUS ret = Old_NtCreateThreadEx(hThread, DesiredAccess,
         ObjectAttributes, ProcessHandle, lpStartAddress, lpParameter,
         CreateFlags | 1, StackZeroBits, SizeOfStackCommit, SizeOfStackReserve,
@@ -189,7 +189,7 @@ HOOKDEF(NTSTATUS, WINAPI, NtCreateThreadEx,
 
 	if (NT_SUCCESS(ret))
 		disable_sleep_skip();
-	
+
 	return ret;
 }
 
@@ -246,7 +246,7 @@ HOOKDEF(NTSTATUS, WINAPI, NtSetContextThread,
 	pipe("PROCESS:%d:%d,%d", is_suspended(pid, tid), pid, tid);
 
 	ret = Old_NtSetContextThread(ThreadHandle, Context);
-	if (Context->ContextFlags & CONTEXT_CONTROL)
+	if (Context != NULL && Context->ContextFlags & CONTEXT_CONTROL)
 #ifdef _WIN64
 		LOQ_ntstatus("threading", "pp", "ThreadHandle", ThreadHandle, "InstructionPointer", Context->Rip);
 #else
@@ -406,10 +406,11 @@ HOOKDEF(NTSTATUS, WINAPI, RtlCreateUserThread,
 ) {
 	DWORD pid;
 	NTSTATUS ret;
+	ENSURE_HANDLE(ThreadHandle);
 	ENSURE_CLIENT_ID(ClientId);
 
 	pid = pid_from_process_handle(ProcessHandle);
-	
+
 	ret = Old_RtlCreateUserThread(ProcessHandle, SecurityDescriptor,
         TRUE, StackZeroBits, StackReserved, StackCommit,
         StartAddress, StartParameter, ThreadHandle, ClientId);

--- a/log.h
+++ b/log.h
@@ -145,6 +145,9 @@ do { \
 #define ENSURE_CLIENT_ID(param) \
     CLIENT_ID _##param; memset(&_##param, 0, sizeof(_##param)); if (param == NULL) param = &_##param
 
+#define ENSURE_HANDLE(param) \
+    HANDLE _##param; memset(&_##param, 0, sizeof(_##param)); if (param == NULL) param = &_##param
+
 #define ENSURE_STRUCT(param, type) \
     type _##param; memset(&_##param, 0, sizeof(_##param)); if(param == NULL) param = &_##param
 


### PR DESCRIPTION
Fixed a parameter validation issue in VirtualProtect/NtProtectVirtualMemory causing problems with malware sample 94095ab2abfd2af1efe301ded2f15814833397937f06b8ba57adfc3e225726e2 when an invalid (but non-NULL) pointer is provided as the last parameter.